### PR TITLE
Revamp site with Tokyo Deep Gem style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# My Website
+# Tokyo Deep Gem
 
-A modern, responsive website built with HTML, CSS, and JavaScript.
+An indie vinyl store website inspired by Tokyo's underground scene.
 
 ## Features
 
@@ -58,7 +58,8 @@ npx serve
 ```
 static-site/
 ├── css/
-│   └── styles.css
+│   ├── styles.css
+│   └── tokyo-deep-gem.css
 ├── js/
 │   └── main.js
 ├── images/

--- a/about.html
+++ b/about.html
@@ -3,10 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>About Us - My Website</title>
-  <meta name="description" content="Learn more about our team and mission">
+  <title>About Us - Tokyo Deep Gem</title>
+  <meta name="description" content="Learn more about our Tokyo indie vinyl shop">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="css/styles.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Mono:wght@400;700&family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
   <style>
     .about-section {
       padding: 4rem 0;
@@ -111,7 +112,7 @@
   <!-- Header -->
   <header class="header">
     <div class="container">
-      <h1>My Website</h1>
+      <h1>Tokyo Deep Gem</h1>
       <nav>
         <ul>
           <li><a href="index.html">Home</a></li>
@@ -127,7 +128,7 @@
   <section class="hero">
     <div class="container">
       <h2>About Us</h2>
-      <p>Learn more about our team and our mission.</p>
+      <p>Discover the story behind our hidden record haven.</p>
     </div>
   </section>
 
@@ -137,9 +138,9 @@
       <div class="about-content">
         <div class="about-text">
           <h2>Our Story</h2>
-          <p>Founded in 2025, My Website was created with a vision to help businesses and individuals establish a strong online presence with modern web technologies.</p>
-          <p>We believe that a well-designed website is essential for success in today's digital world. Our team combines technical expertise with creative design to deliver websites that not only look great but also perform exceptionally well.</p>
-          <p>Our approach is centered around understanding our clients' unique needs and delivering solutions that exceed their expectations. We pride ourselves on attention to detail, responsive communication, and delivering projects on time and within budget.</p>
+          <p>Opened in 2016, Tokyo Deep Gem began as a tiny record stand tucked away in a Shibuya side street.</p>
+          <p>We curate an eclectic mix of indie releases, city pop classics, and experimental sounds that capture the soul of Tokyo's underground.</p>
+          <p>Built by collectors for collectors, our shop focuses on quality pressings and a welcoming vibe for anyone who loves vinyl.</p>
         </div>
         <div class="about-image">
           <img src="https://images.unsplash.com/photo-1522071820081-009f0129c71c?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1740&q=80" alt="Team working together">
@@ -211,7 +212,7 @@
   <!-- Footer -->
   <footer class="footer">
     <div class="container">
-      <p>&copy; 2025 My Website. All rights reserved.</p>
+      <p>&copy; 2025 Tokyo Deep Gem. All rights reserved.</p>
       <ul class="social-links">
         <li><a href="#"><i class="fab fa-facebook"></i></a></li>
         <li><a href="#"><i class="fab fa-twitter"></i></a></li>

--- a/backup/index.html
+++ b/backup/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Vinyl Universe</title>
-  <meta name="description" content="An immersive vinyl record listening experience">
+  <title>Tokyo Deep Gem</title>
+  <meta name="description" content="An indie vinyl store hidden in Tokyo's nightlife">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/vinyl-universe-industrial.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Mono:wght@400;700&family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/tokyo-deep-gem.css">
 </head>
 <body>
 
@@ -20,7 +20,7 @@
   <div class="universe-container">
     <!-- Header -->
     <header class="universe-header">
-      <h1 class="universe-logo">VINYL UNIVERSE <span class="header-subtitle">premium collection</span></h1>
+      <h1 class="universe-logo">TOKYO DEEP GEM <span class="header-subtitle">indie vinyl store</span></h1>
       <nav class="universe-nav">
         <a href="#" class="nav-link">Collection</a>
         <a href="#" class="nav-link">About</a>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,9 +1,9 @@
 /* Base styles */
 :root {
-  --primary-color: #3b82f6;
-  --secondary-color: #f59e0b;
-  --dark-color: #1f2937;
-  --light-color: #f9fafb;
+  --primary-color: #e60073;
+  --secondary-color: #14ffec;
+  --dark-color: #101010;
+  --light-color: #f9f9f9;
   --success-color: #10b981;
   --warning-color: #f59e0b;
   --danger-color: #ef4444;
@@ -16,9 +16,9 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-  background-color: var(--light-color);
-  color: var(--dark-color);
+  font-family: 'Inter', 'Noto Sans JP', sans-serif;
+  background-color: var(--dark-color);
+  color: var(--light-color);
   line-height: 1.6;
 }
 

--- a/css/tokyo-deep-gem.css
+++ b/css/tokyo-deep-gem.css
@@ -1,0 +1,12 @@
+@import url('vinyl-universe.css');
+
+:root {
+  --primary-dark: #0b0b0f;
+  --secondary-dark: #181825;
+  --accent-glow: #ff4da6;
+  --accent-neon: #14ffec;
+  --accent-rose: #ff006e;
+  --accent-yellow: #ffd300;
+  --text-primary: #f5f5f5;
+  --text-secondary: #cbd5e1;
+}

--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Vinyl Universe</title>
-  <meta name="description" content="An immersive vinyl record listening experience">
+  <title>Tokyo Deep Gem</title>
+  <meta name="description" content="An indie vinyl store hidden in Tokyo's nightlife">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/vinyl-universe-industrial.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Mono:wght@400;700&family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/tokyo-deep-gem.css">
 </head>
 <body>
 
@@ -20,7 +20,7 @@
   <div class="universe-container">
     <!-- Header -->
     <header class="universe-header">
-      <h1 class="universe-logo">VINYL UNIVERSE <span class="header-subtitle">premium collection</span></h1>
+      <h1 class="universe-logo">TOKYO DEEP GEM <span class="header-subtitle">indie vinyl store</span></h1>
       <nav class="universe-nav">
         <a href="#" class="nav-link">Collection</a>
         <a href="#" class="nav-link">About</a>

--- a/index.html.local
+++ b/index.html.local
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Vinyl Universe</title>
-  <meta name="description" content="An immersive vinyl record listening experience">
+  <title>Tokyo Deep Gem</title>
+  <meta name="description" content="An indie vinyl store hidden in Tokyo's nightlife">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/vinyl-universe-industrial.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Mono:wght@400;700&family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/tokyo-deep-gem.css">
 </head>
 <body>
 
@@ -20,7 +20,7 @@
   <div class="universe-container">
     <!-- Header -->
     <header class="universe-header">
-      <h1 class="universe-logo">VINYL UNIVERSE <span class="header-subtitle">premium collection</span></h1>
+      <h1 class="universe-logo">TOKYO DEEP GEM <span class="header-subtitle">indie vinyl store</span></h1>
       <nav class="universe-nav">
         <a href="#" class="nav-link">Collection</a>
         <a href="#" class="nav-link">About</a>


### PR DESCRIPTION
## Summary
- switch site branding to **Tokyo Deep Gem**
- add new neon-inspired `tokyo-deep-gem.css`
- update index and backup pages to use the new style
- restyle about page text and footer
- add Japanese font and dark theme palette
- update README docs

## Testing
- `git status --short`